### PR TITLE
fix php8.4 deprecation warnings

### DIFF
--- a/src/Exceptions/NanoIDException.php
+++ b/src/Exceptions/NanoIDException.php
@@ -45,7 +45,7 @@ class NanoIDException extends Exception
         return $this;
     }
 
-    public static function prefixSuffixTooLong(int $length, string $prefix = null, string $suffix = null): self
+    public static function prefixSuffixTooLong(int $length, ?string $prefix = null, ?string $suffix = null): self
     {
         $nanoIDException = new self(
             'The combined length of the prefix and suffix is longer than the requested length.'

--- a/src/NanoID.php
+++ b/src/NanoID.php
@@ -28,7 +28,7 @@ class NanoID implements Stringable
         $this->alphabet = $alphabet ?? config('nano-id.alphabet');
     }
 
-    public function generate(int $length = null, string $symbols = null): string
+    public function generate(int $length = null, ?string $symbols = null): string
     {
         $limit = (int) ($length > 0 ? $length : $this->size);
         $prefix = config('nano-id.prefix', '');

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,7 +3,7 @@
 use Fanmade\NanoId\Facades\NanoID;
 
 if (!function_exists('nano_id')) {
-    function nano_id(?int $length = null, string $alphabet = null): string
+    function nano_id(?int $length = null, ?string $alphabet = null): string
     {
         return NanoID::generate($length, $alphabet);
     }


### PR DESCRIPTION
Fixing this deprecation for php 8.4:

`Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead`